### PR TITLE
Fix indent when formatting empty files

### DIFF
--- a/libs/merge_utils.py
+++ b/libs/merge_utils.py
@@ -65,10 +65,10 @@ def _merge_code(view, edit, code, formatted):
 def merge_code(view, edit, code, formatted_code):
     vs = view.settings()
     ttts = vs.get("translate_tabs_to_spaces")
-    vs.set("translate_tabs_to_spaces", False)
     if not code.strip():
         return (False, '')
 
+    vs.set("translate_tabs_to_spaces", False)
     dirty = False
     err = ''
     try:


### PR DESCRIPTION
JsFormat currently overrides the _Indent Using Spaces_ setting when formatting empty files. This is a problem when `format_on_save` is enabled as it forces all new Javascript files to use tabs for indents. To reproduce the bug:

1.  Create an empty file and save it with a `.js` extension
2.  Enable the _Indent Using Spaces_ setting in the bottom right corner of the Sublime window
3.  Format the file using JsFormat (`ctrl` + `option` + `f`)
4.  The _Indent Using Spaces_ setting is overwritten

This is happening because:

- `merge_utils.py` forces `translate_tabs_to_spaces` to false ([line 68](https://github.com/jdc0589/JsFormat/blob/master/libs/merge_utils.py#L68)) and later restores it to the user's chosen option ([line 83](https://github.com/jdc0589/JsFormat/blob/master/libs/merge_utils.py#L83))
- However, when there is no code in the file (e.g. a brand new file), the `merge_code` function returns early _before_ the user's indent preferences have been restored ([line 70](https://github.com/jdc0589/JsFormat/blob/master/libs/merge_utils.py#L70))
- This currently results in `translates_tabs_to_spaces` being forced to `false` when saving any empty Javascript file

This PR fixes this by ensuring `merge_code` returns _before_ forcing tabs if the file is empty