### PR TITLE
Add the "hidden" space after anonymous function option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following **JsBeautifier** settings are available in JsFormat/JsFormat.subli
 * `break_chained_methods`: false*
 * `e4x`: false
 * `wrap_line_length`: 0
+* `space_after_anon_function`: false
 
 The following **JsFormat** specific settings are also exposed:
 


### PR DESCRIPTION
I was looking for this option. The only place where it has been discussed and where I found it, is this issue:
https://github.com/jdc0589/JsFormat/issues/64

I believe it's better to have it listed in the readme.