### PR TITLE
"Format: Javascript" doesn't show up Fix

### DIFF
--- a/js_formatter.py
+++ b/js_formatter.py
@@ -78,7 +78,7 @@ class JsFormatCommand(sublime_plugin.TextCommand):
 
         if file_name is not None and s.get("ignore_sublime_settings"):
             _, ext = os.path.splitext(file_name)
-            if ext in {".sublime-settings", ".sublime-project"}:
+            if ext in [".sublime-settings", ".sublime-project"]:
                 return
 
         # settings


### PR DESCRIPTION
After install the plugin, this is the error message in console ST2:
```
Reloading plugin /home/wuilliam/.config/sublime-text-2/Packages/JsFormat/js_formatter.py
Traceback (most recent call last):
  File "./sublime_plugin.py", line 62, in reload_plugin
  File "./js_formatter.py", line 81
    if ext in {".sublime-settings", ".sublime-project"}:
                                  ^
SyntaxError: invalid syntax
```

I change the dictionary for a list, and it was solved. I love this plugin! i hope it helps