### PR TITLE
Fixes #141 where JsFormat does not start on ST2

### DIFF
--- a/JsFormat.sublime-settings
+++ b/JsFormat.sublime-settings
@@ -17,5 +17,5 @@
 	// jsformat options
 	"format_on_save": false,
 	"jsbeautifyrc_files": false,
-	"ignore_sublime_settings": true,
+	"ignore_sublime_settings": true
 }

--- a/js_formatter.py
+++ b/js_formatter.py
@@ -78,7 +78,7 @@ class JsFormatCommand(sublime_plugin.TextCommand):
 
         if file_name is not None and s.get("ignore_sublime_settings"):
             _, ext = os.path.splitext(file_name)
-            if ext in {".sublime-settings", ".sublime-project"}:
+            if ext in [".sublime-settings", ".sublime-project"]:
                 return
 
         # settings


### PR DESCRIPTION
Fixes JsFormat in ST2
- remove trailing comma
- use list instead of dictionary to fix python syntax in js_formatter.py