### PR TITLE
Allow to disable "format_selection"

### DIFF
--- a/JsFormat.sublime-settings
+++ b/JsFormat.sublime-settings
@@ -16,6 +16,7 @@
 
 	// jsformat options
 	"format_on_save": false,
+	"format_selection": true,
 	"jsbeautifyrc_files": false,
 	"ignore_sublime_settings": true
 }

--- a/js_formatter.py
+++ b/js_formatter.py
@@ -93,7 +93,7 @@ class JsFormatCommand(sublime_plugin.TextCommand):
         selection = self.view.sel()[0]
 
         # formatting a selection/highlighted area
-        if(len(selection) > 0):
+        if(len(selection) > 0 and s.get("format_selection")):
             jsf.format_selection(self.view, edit, opts)
         else:
             jsf.format_whole_file(self.view, edit, opts)


### PR DESCRIPTION
Hi there!

format_selection is very annoying 

1. It changes the selection to scope (or something like that)
2. It also mismatch the indentation used in the file, means that if you format a selection and then the whole file, the format will also change. 
3. Completely breaks the format in some situations where the selection may not be valid as is, but valid in the context of the complete document. 

It does more harm than good in my use case, so I added a preference to disable it, with default value as current behaviour.

Thanks!